### PR TITLE
feat: add responsive layout and navigation skeleton

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,16 +1,35 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-
-// Import page components
 import DashboardPage from './pages/Dashboard';
+import Layout from './components/common/Layout';
+import { NavigationProvider } from './context/NavigationContext';
+import { ThemeProvider } from './context/ThemeContext';
 
 const AppRoutes = () => {
   return (
     <Router>
-      <Routes>
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/" element={<DashboardPage />} />
-      </Routes>
+      <ThemeProvider>
+        <NavigationProvider>
+          <Routes>
+            <Route
+              path="/dashboard"
+              element={
+                <Layout>
+                  <DashboardPage />
+                </Layout>
+              }
+            />
+            <Route
+              path="/"
+              element={
+                <Layout>
+                  <DashboardPage />
+                </Layout>
+              }
+            />
+          </Routes>
+        </NavigationProvider>
+      </ThemeProvider>
     </Router>
   );
 };

--- a/src/components/common/BottomNavigation.tsx
+++ b/src/components/common/BottomNavigation.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { useNavigation } from '../../hooks/useNavigation';
+
+const BottomNavigation: React.FC = () => {
+  const { items, activePath } = useNavigation();
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 flex justify-around bg-global-4 border-t md:hidden">
+      {items.map((item) => (
+        <NavLink
+          key={item.id}
+          to={item.path}
+          className="flex flex-col items-center p-2"
+        >
+          <img src={item.icon} alt="" className="w-6 h-6" />
+          <span
+            className={`text-xs ${
+              activePath === item.path ? 'text-header-1' : 'text-global-2'
+            }`}
+          >
+            {item.label}
+          </span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+};
+
+export default BottomNavigation;
+

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,61 +1,70 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useResponsive } from '../../hooks/useResponsive';
+import { useTheme } from '../../hooks/useTheme';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onMenuToggle?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
   const navigate = useNavigate();
+  const { isMobile } = useResponsive();
+  const { theme, setTheme } = useTheme();
 
   return (
-    <div className="absolute top-[13px] left-[336px] w-[1078px] h-[67px]">
-      <div className="flex items-center justify-between w-full h-full bg-global-4 rounded-[10px] px-6">
-        <div className="flex items-center gap-6">
-          <span className="text-[19px] font-raleway font-medium leading-[23px] text-global-1">
-            Thu, 3 April
-          </span>
-          <span className="text-[19px] font-raleway font-medium leading-[23px] text-global-1">
-            4:34 pm
-          </span>
-        </div>
-        
-        <div className="flex items-center gap-4">
-          <img 
-            src="/images/img_ellipse_1.png" 
-            alt="Profile"
-            className="w-[42px] h-[42px] rounded-[21px] cursor-pointer"
-            onClick={() => navigate('/profile')}
-          />
-          
-          <div className="flex flex-col">
-            <span className="text-[16px] font-raleway font-semibold leading-[19px] text-global-1">
-              Dr. Jhon Doe
-            </span>
-            <span className="text-[14px] font-raleway font-normal leading-[17px] text-header-1">
-              Doctor
-            </span>
-          </div>
-          
-          <div className="w-[1px] h-[34px] bg-global-1 opacity-30"></div>
-          
-          <img 
-            src="/images/img_famiconsnotificationsoutline.svg" 
-            alt="Notifications"
-            className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
-          />
-          
-          <img 
-            src="/images/img_weuisettingoutlined.svg" 
-            alt="Settings"
-            className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
-          />
-          
-          <img 
-            src="/images/img_iconoirlogout.svg" 
-            alt="Logout"
-            className="w-[28px] h-[28px] cursor-pointer hover:opacity-80"
-          />
-        </div>
+    <header className="flex h-16 items-center justify-between bg-global-4 px-4 shadow md:px-6">
+      {isMobile && (
+        <button
+          aria-label="Open menu"
+          onClick={onMenuToggle}
+          className="p-2"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      )}
+      <div className="flex items-center gap-2">
+        <span className="text-header-1 font-raleway text-lg font-semibold">MedVoice</span>
       </div>
-    </div>
+      <div className="flex items-center gap-4">
+        <button
+          aria-label="Toggle theme"
+          onClick={() => setTheme(theme === 'dark' ? 'default' : 'dark')}
+          className="p-2 hover:opacity-80"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 3v1m0 16v1m8.66-13.66l-.7.7M4.04 19.96l-.7.7M21 12h-1M4 12H3m16.66 7.66l-.7-.7M4.04 4.04l-.7-.7M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+            />
+          </svg>
+        </button>
+        <img
+          src="/images/img_ellipse_1.png"
+          alt="Profile"
+          className="h-8 w-8 rounded-full cursor-pointer"
+          onClick={() => navigate('/profile')}
+        />
+      </div>
+    </header>
   );
 };
 
 export default Header;
+

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { LayoutProps } from '../../types/layout.types';
+import Sidebar from './Sidebar';
+import Header from './Header';
+import BottomNavigation from './BottomNavigation';
+import MobileMenu from './MobileMenu';
+import { useResponsive } from '../../hooks/useResponsive';
+import { useMobileMenu } from '../../hooks/useMobileMenu';
+
+const Layout: React.FC<LayoutProps> = ({
+  children,
+  showHeader = true,
+  showSidebar = true,
+  showBottomNav = true,
+}) => {
+  const { isMobile } = useResponsive();
+  const mobileMenu = useMobileMenu();
+
+  return (
+    <div className="flex min-h-screen bg-global-3">
+      {showSidebar && !isMobile && <Sidebar />}
+      <MobileMenu open={mobileMenu.open} onClose={mobileMenu.closeMenu} />
+      <div className="flex flex-1 flex-col">
+        {showHeader && <Header onMenuToggle={mobileMenu.openMenu} />}
+        <main className="flex-1 p-4">{children}</main>
+        {showBottomNav && isMobile && <BottomNavigation />}
+      </div>
+    </div>
+  );
+};
+
+export default Layout;
+

--- a/src/components/common/MobileMenu.tsx
+++ b/src/components/common/MobileMenu.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { useNavigation } from '../../hooks/useNavigation';
+
+interface MobileMenuProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const MobileMenu: React.FC<MobileMenuProps> = ({ open, onClose }) => {
+  const { items } = useNavigation();
+
+  return (
+    <div
+      className={`fixed inset-0 z-40 bg-black bg-opacity-50 transition-opacity duration-300 ${
+        open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      }`}
+      onClick={onClose}
+      aria-hidden={!open}
+    >
+      <div
+        className={`h-full w-64 bg-sidebar-1 text-global-3 transform transition-transform duration-300 ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <nav className="mt-10">
+          {items.map((item) => (
+            <NavLink
+              key={item.id}
+              to={item.path}
+              className="block px-4 py-3 hover:bg-global-2"
+              onClick={onClose}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default MobileMenu;
+

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,64 +1,61 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useNavigation } from '../../hooks/useNavigation';
+import { useResponsive } from '../../hooks/useResponsive';
 
 const Sidebar: React.FC = () => {
-  const navigate = useNavigate();
-
-  const menuItems = [
-    { icon: '/images/img_mynauihome.svg', label: 'Home', path: '/', active: true },
-    { icon: '/images/img_magedashboard.svg', label: 'Dashboard', path: '/dashboard', active: false },
-    { icon: '/images/img_image_8.png', label: 'Calender', path: '/calendar', active: false },
-    { icon: '/images/img_image_9.png', label: 'Profile', path: '/profile', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-2', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-3', active: false }
-  ];
+  const { items, activePath } = useNavigation();
+  const { isDesktop } = useResponsive();
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div className="absolute top-0 left-0 w-[310px] h-[841px] bg-sidebar-1 flex flex-col">
-      {/* Logo Section */}
-      <div className="flex items-center justify-between mt-[37px] ml-[22px] mr-[27px]">
-        <img 
-          src="/images/img_sidebarlogo.png" 
-          alt="Logo"
-          className="w-[112px] h-[47px]"
-        />
-        <div className="w-[40px] h-[40px] bg-global-4 rounded-[20px] flex items-center justify-center shadow-sm cursor-pointer hover:opacity-80">
-          <img 
-            src="/images/img_materialsymbolslightarrowback.svg" 
-            alt="Collapse"
-            className="w-[27px] h-[27px]"
-          />
-        </div>
-      </div>
-
-      {/* Menu Items */}
-      <div className="flex flex-col mt-[66px] gap-[22px]">
-        {menuItems.map((item, index) => (
-          <div
-            key={index}
-            onClick={() => navigate(item.path)}
-            className={`
-              flex items-center mx-[22px] px-[29px] py-[16px] rounded-[15px] cursor-pointer transition-all duration-200
-              ${item.active ? 'bg-global-4' : 'hover:bg-global-2'}
-            `}
+    <aside
+      className={`hidden bg-sidebar-1 text-global-3 transition-all duration-300 md:flex md:flex-col ${
+        collapsed ? 'w-16' : 'w-64'
+      }`}
+    >
+      <div className="flex items-center justify-between p-4">
+        <img src="/images/img_sidebarlogo.png" alt="Logo" className="h-8" />
+        {isDesktop && (
+          <button
+            aria-label="Collapse sidebar"
+            onClick={() => setCollapsed((v) => !v)}
+            className="p-2 hover:opacity-80"
           >
-            <img 
-              src={item.icon} 
-              alt={item.label}
-              className="w-[27px] h-[27px] mr-[11px]"
-            />
-            <span className={`
-              text-[20px] font-raleway leading-[24px]
-              ${item.active ? 'font-medium text-global-1' : 'font-normal text-global-3'}
-            `}>
-              {item.label}
-            </span>
-          </div>
-        ))}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+        )}
       </div>
-    </div>
+      <nav className="flex-1">
+        {items.map((item) => (
+          <NavLink
+            key={item.id}
+            to={item.path}
+            className={`flex items-center gap-3 px-4 py-2 hover:bg-global-2 transition-colors ${
+              activePath === item.path ? 'bg-global-2' : ''
+            }`}
+          >
+            <img src={item.icon} alt="" className="h-5 w-5" />
+            {!collapsed && <span>{item.label}</span>}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
   );
 };
 
 export default Sidebar;
+

--- a/src/context/NavigationContext.tsx
+++ b/src/context/NavigationContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { NavigationItem } from '../types/navigation.types';
+
+interface NavigationContextType {
+  items: NavigationItem[];
+  activePath: string;
+}
+
+export const NavigationContext = createContext<NavigationContextType>({
+  items: [],
+  activePath: '/',
+});
+
+export const NavigationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+
+  const items = useMemo<NavigationItem[]>(
+    () => [
+      { id: 'home', label: 'Home', path: '/', icon: '/images/img_mynauihome.svg' },
+      { id: 'dashboard', label: 'Dashboard', path: '/dashboard', icon: '/images/img_magedashboard.svg' },
+      { id: 'calendar', label: 'Calendar', path: '/calendar', icon: '/images/img_image_8.png' },
+      { id: 'profile', label: 'Profile', path: '/profile', icon: '/images/img_image_9.png' },
+      { id: 'extra', label: 'Extra', path: '/extra', icon: '/images/img_image_9.png' },
+    ],
+    [],
+  );
+
+  return (
+    <NavigationContext.Provider value={{ items, activePath: location.pathname }}>
+      {children}
+    </NavigationContext.Provider>
+  );
+};
+

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useEffect, useState } from 'react';
+
+export type Theme = 'default' | 'purple' | 'dark' | 'medical';
+
+export interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  isDarkMode: boolean;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'default',
+  setTheme: () => undefined,
+  isDarkMode: false,
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem('theme') as Theme) || 'default');
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, isDarkMode: theme === 'dark' }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+

--- a/src/hooks/useMobileMenu.ts
+++ b/src/hooks/useMobileMenu.ts
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export const useMobileMenu = () => {
+  const [open, setOpen] = useState(false);
+  const openMenu = () => setOpen(true);
+  const closeMenu = () => setOpen(false);
+  return { open, openMenu, closeMenu };
+};
+

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { NavigationContext } from '../context/NavigationContext';
+
+export const useNavigation = () => useContext(NavigationContext);
+

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+const MOBILE_MAX = 768;
+const TABLET_MAX = 1024;
+
+export const useResponsive = () => {
+  const [width, setWidth] = useState<number>(typeof window !== 'undefined' ? window.innerWidth : MOBILE_MAX);
+
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return {
+    width,
+    isMobile: width < MOBILE_MAX,
+    isTablet: width >= MOBILE_MAX && width < TABLET_MAX,
+    isDesktop: width >= TABLET_MAX,
+  };
+};
+

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../context/ThemeContext';
+
+export const useTheme = () => useContext(ThemeContext);
+

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import Header from '../../components/common/Header';
-import Sidebar from '../../components/common/Sidebar';
 import Button from '../../components/ui/Button';
 import Dropdown from '../../components/ui/Dropdown';
 
@@ -103,11 +101,7 @@ Lorem ipsum" is placeholder text, or dummy text, used in graphic design, publish
 
   return (
     <div className="relative w-[1440px] h-[841px] bg-global-3">
-      {/* Sidebar */}
-      <Sidebar />
-      
-      {/* Header */}
-      <Header />
+      {/* Layout now provides Header and Sidebar */}
       
       {/* Main Content Area */}
       <div className="absolute top-[100px] left-[336px] flex gap-0">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -22,6 +22,18 @@
     /* Button Colors */
     --button-bg-1: #1472ff;
   }
+
+  :root[data-theme='dark'] {
+    --global-bg-3: #1f2937;
+    --global-bg-4: #111827;
+    --global-text-1: #ffffff;
+    --global-text-2: #d1d5db;
+    --sidebar-bg-1: #111827;
+  }
+
+  :root[data-theme='purple'] {
+    --sidebar-bg-1: #6b21a8;
+  }
 }
 
 @layer utilities {

--- a/src/types/layout.types.ts
+++ b/src/types/layout.types.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export interface LayoutProps {
+  children: React.ReactNode;
+  title?: string;
+  showHeader?: boolean;
+  showSidebar?: boolean;
+  showBottomNav?: boolean;
+}
+

--- a/src/types/navigation.types.ts
+++ b/src/types/navigation.types.ts
@@ -1,0 +1,10 @@
+export interface NavigationItem {
+  id: string;
+  label: string;
+  path: string;
+  icon: string;
+  active?: boolean;
+  badge?: number;
+  disabled?: boolean;
+}
+


### PR DESCRIPTION
## Summary
- scaffold responsive Layout component integrating sidebar, header, mobile menu and bottom navigation
- introduce navigation and theme contexts with hooks for breakpoint and theme management
- add basic mobile-friendly header, collapsible sidebar, bottom navigation and slide-in mobile menu

## Testing
- `npm test` (fails: Missing script)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688de92b06c08333ad1479593888ca1f