### PR TITLE
feat: add responsive layout and navigation

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Layout from './components/common/Layout';
 
 // Import page components
 import DashboardPage from './pages/Dashboard';
+import CalendarPage from './pages/Calendar';
+import ProfilePage from './pages/Profile';
+import ExtraPage from './pages/Extra';
+import ExtraTwoPage from './pages/ExtraTwo';
+import ExtraThreePage from './pages/ExtraThree';
 
 const AppRoutes = () => {
   return (
     <Router>
       <Routes>
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/" element={<DashboardPage />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/extra" element={<ExtraPage />} />
+          <Route path="/extra-2" element={<ExtraTwoPage />} />
+          <Route path="/extra-3" element={<ExtraThreePage />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,60 +1,78 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../../context/ThemeContext';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onMenuClick: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
   const navigate = useNavigate();
+  const { toggleTheme } = useTheme();
 
   return (
-    <div className="absolute top-[13px] left-[336px] w-[1078px] h-[67px]">
-      <div className="flex items-center justify-between w-full h-full bg-global-4 rounded-[10px] px-6">
-        <div className="flex items-center gap-6">
-          <span className="text-[19px] font-raleway font-medium leading-[23px] text-global-1">
-            Thu, 3 April
-          </span>
-          <span className="text-[19px] font-raleway font-medium leading-[23px] text-global-1">
-            4:34 pm
-          </span>
-        </div>
-        
-        <div className="flex items-center gap-4">
-          <img 
-            src="/images/img_ellipse_1.png" 
-            alt="Profile"
-            className="w-[42px] h-[42px] rounded-[21px] cursor-pointer"
-            onClick={() => navigate('/profile')}
+    <header className="flex items-center justify-between h-16 bg-global-4 px-4 shadow-md fixed top-0 left-0 right-0 lg:left-[280px] z-30">
+      <div className="flex items-center gap-4">
+        <button className="lg:hidden" onClick={onMenuClick} aria-label="Open sidebar">
+          <img
+            src="/images/img_materialsymbolslightarrowback.svg"
+            alt="menu"
+            className="w-6 h-6 rotate-180"
           />
-          
-          <div className="flex flex-col">
-            <span className="text-[16px] font-raleway font-semibold leading-[19px] text-global-1">
-              Dr. Jhon Doe
-            </span>
-            <span className="text-[14px] font-raleway font-normal leading-[17px] text-header-1">
-              Doctor
-            </span>
-          </div>
-          
-          <div className="w-[1px] h-[34px] bg-global-1 opacity-30"></div>
-          
-          <img 
-            src="/images/img_famiconsnotificationsoutline.svg" 
-            alt="Notifications"
-            className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
-          />
-          
-          <img 
-            src="/images/img_weuisettingoutlined.svg" 
-            alt="Settings"
-            className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
-          />
-          
-          <img 
-            src="/images/img_iconoirlogout.svg" 
-            alt="Logout"
-            className="w-[28px] h-[28px] cursor-pointer hover:opacity-80"
-          />
-        </div>
+        </button>
+        <span className="hidden md:block text-[19px] font-raleway font-medium leading-[23px] text-global-1">
+          Thu, 3 April
+        </span>
+        <span className="hidden md:block text-[19px] font-raleway font-medium leading-[23px] text-global-1">
+          4:34 pm
+        </span>
       </div>
-    </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          onClick={toggleTheme}
+          className="w-8 h-8 rounded-full bg-button-1 text-global-3 flex items-center justify-center"
+          aria-label="Toggle theme"
+        >
+          🌓
+        </button>
+        <img
+          src="/images/img_ellipse_1.png"
+          alt="Profile"
+          className="w-[42px] h-[42px] rounded-[21px] cursor-pointer"
+          onClick={() => navigate('/profile')}
+        />
+
+        <div className="hidden sm:flex flex-col">
+          <span className="text-[16px] font-raleway font-semibold leading-[19px] text-global-1">
+            Dr. Jhon Doe
+          </span>
+          <span className="text-[14px] font-raleway font-normal leading-[17px] text-header-1">
+            Doctor
+          </span>
+        </div>
+
+        <div className="w-[1px] h-[34px] bg-global-1 opacity-30" />
+
+        <img
+          src="/images/img_famiconsnotificationsoutline.svg"
+          alt="Notifications"
+          className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
+        />
+
+        <img
+          src="/images/img_weuisettingoutlined.svg"
+          alt="Settings"
+          className="w-[31px] h-[31px] cursor-pointer hover:opacity-80"
+        />
+
+        <img
+          src="/images/img_iconoirlogout.svg"
+          alt="Logout"
+          className="w-[28px] h-[28px] cursor-pointer hover:opacity-80"
+        />
+      </div>
+    </header>
   );
 };
 

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import Sidebar from './Sidebar';
+import Header from './Header';
+
+const Layout: React.FC = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen bg-global-3 lg:pl-[280px]">
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <div className="flex flex-col flex-1 min-h-screen">
+        <Header onMenuClick={() => setSidebarOpen(true)} />
+        <main className="flex-1 p-4 mt-16">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,63 +1,84 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
 
   const menuItems = [
-    { icon: '/images/img_mynauihome.svg', label: 'Home', path: '/', active: true },
-    { icon: '/images/img_magedashboard.svg', label: 'Dashboard', path: '/dashboard', active: false },
-    { icon: '/images/img_image_8.png', label: 'Calender', path: '/calendar', active: false },
-    { icon: '/images/img_image_9.png', label: 'Profile', path: '/profile', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-2', active: false },
-    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-3', active: false }
+    { icon: '/images/img_mynauihome.svg', label: 'Home', path: '/' },
+    { icon: '/images/img_magedashboard.svg', label: 'Dashboard', path: '/dashboard' },
+    { icon: '/images/img_image_8.png', label: 'Calendar', path: '/calendar' },
+    { icon: '/images/img_image_9.png', label: 'Profile', path: '/profile' },
+    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra' },
+    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-2' },
+    { icon: '/images/img_image_9.png', label: 'Extra', path: '/extra-3' },
   ];
 
-  return (
-    <div className="absolute top-0 left-0 w-[310px] h-[841px] bg-sidebar-1 flex flex-col">
-      {/* Logo Section */}
-      <div className="flex items-center justify-between mt-[37px] ml-[22px] mr-[27px]">
-        <img 
-          src="/images/img_sidebarlogo.png" 
-          alt="Logo"
-          className="w-[112px] h-[47px]"
-        />
-        <div className="w-[40px] h-[40px] bg-global-4 rounded-[20px] flex items-center justify-center shadow-sm cursor-pointer hover:opacity-80">
-          <img 
-            src="/images/img_materialsymbolslightarrowback.svg" 
-            alt="Collapse"
-            className="w-[27px] h-[27px]"
-          />
-        </div>
-      </div>
+  const activeClass = (path: string) =>
+    location.pathname === path
+      ? 'bg-global-4 text-global-1 font-medium'
+      : 'hover:bg-global-2 text-global-3';
 
-      {/* Menu Items */}
-      <div className="flex flex-col mt-[66px] gap-[22px]">
-        {menuItems.map((item, index) => (
-          <div
-            key={index}
-            onClick={() => navigate(item.path)}
-            className={`
-              flex items-center mx-[22px] px-[29px] py-[16px] rounded-[15px] cursor-pointer transition-all duration-200
-              ${item.active ? 'bg-global-4' : 'hover:bg-global-2'}
-            `}
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className={`fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden ${isOpen ? 'block' : 'hidden'}`}
+        onClick={onClose}
+      />
+      {/* Sidebar content */}
+      <nav
+        className={`fixed top-0 left-0 z-50 w-[280px] h-full bg-sidebar-1 flex flex-col transform transition-transform duration-300
+        ${isOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:static lg:block`}
+      >
+        {/* Logo Section */}
+        <div className="flex items-center justify-between mt-[37px] ml-[22px] mr-[27px]">
+          <img src="/images/img_sidebarlogo.png" alt="Logo" className="w-[112px] h-[47px]" />
+          <button
+            className="w-[40px] h-[40px] bg-global-4 rounded-[20px] flex items-center justify-center shadow-sm cursor-pointer hover:opacity-80"
+            onClick={onClose}
+            aria-label="Collapse sidebar"
           >
-            <img 
-              src={item.icon} 
-              alt={item.label}
-              className="w-[27px] h-[27px] mr-[11px]"
+            <img
+              src="/images/img_materialsymbolslightarrowback.svg"
+              alt="Collapse"
+              className="w-[27px] h-[27px]"
             />
-            <span className={`
-              text-[20px] font-raleway leading-[24px]
-              ${item.active ? 'font-medium text-global-1' : 'font-normal text-global-3'}
-            `}>
-              {item.label}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
+          </button>
+        </div>
+
+        {/* Menu Items */}
+        <div className="flex flex-col mt-[66px] gap-[22px]">
+          {menuItems.map((item, index) => (
+            <div
+              key={index}
+              onClick={() => {
+                navigate(item.path);
+                onClose();
+              }}
+              className={`flex items-center mx-[22px] px-[29px] py-[16px] rounded-[15px] cursor-pointer transition-all duration-200 ${activeClass(item.path)}`}
+            >
+              <img src={item.icon} alt={item.label} className="w-[27px] h-[27px] mr-[11px]" />
+              <span className="text-[20px] font-raleway leading-[24px]">{item.label}</span>
+            </div>
+          ))}
+        </div>
+      </nav>
+    </>
   );
 };
 

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface ThemeContextType {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const prefersDark =
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const [theme, setTheme] = useState<'light' | 'dark'>(prefersDark ? 'dark' : 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default ThemeContext;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './styles/index.css';
+import { ThemeProvider } from './context/ThemeContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
+    <ThemeProvider>
       <App />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CalendarPage: React.FC = () => {
+  return <div className="p-4">Calendar page placeholder</div>;
+};
+
+export default CalendarPage;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import Header from '../../components/common/Header';
-import Sidebar from '../../components/common/Sidebar';
 import Button from '../../components/ui/Button';
 import Dropdown from '../../components/ui/Dropdown';
 
@@ -16,7 +14,7 @@ const Dashboard: React.FC = () => {
     isRecording: false,
     isPaused: false,
     duration: '0:04',
-    audioBlob: null
+    audioBlob: null,
   });
 
   const [textContent, setTextContent] = useState<string>(
@@ -33,17 +31,17 @@ Lorem ipsum" is placeholder text, or dummy text, used in graphic design, publish
   const sizeOptions = ['Size: 10', 'Size: 12', 'Size: 14', 'Size: 16', 'Size: 18', 'Size: 20'];
 
   const handleStartRecording = () => {
-    setVoiceState(prev => ({ ...prev, isRecording: true, isPaused: false }));
+    setVoiceState((prev) => ({ ...prev, isRecording: true, isPaused: false }));
     console.log('Recording started');
   };
 
   const handlePauseRecording = () => {
-    setVoiceState(prev => ({ ...prev, isPaused: !prev.isPaused }));
+    setVoiceState((prev) => ({ ...prev, isPaused: !prev.isPaused }));
     console.log('Recording paused/resumed');
   };
 
   const handleStopRecording = () => {
-    setVoiceState(prev => ({ ...prev, isRecording: false, isPaused: false }));
+    setVoiceState((prev) => ({ ...prev, isRecording: false, isPaused: false }));
     console.log('Recording stopped');
   };
 
@@ -57,7 +55,7 @@ Lorem ipsum" is placeholder text, or dummy text, used in graphic design, publish
   };
 
   const handleDeleteRecording = () => {
-    setVoiceState(prev => ({ ...prev, audioBlob: null, duration: '0:00' }));
+    setVoiceState((prev) => ({ ...prev, audioBlob: null, duration: '0:00' }));
     console.log('Recording deleted');
   };
 
@@ -79,149 +77,148 @@ Lorem ipsum" is placeholder text, or dummy text, used in graphic design, publish
       title: 'View / Manage Prescriptions',
       image: '/images/img_image_1.png',
       background: '/images/img_.png',
-      onClick: () => console.log('Navigate to prescriptions')
+      onClick: () => console.log('Navigate to prescriptions'),
     },
     {
       title: 'View / Manage Consultations',
       image: '/images/img_image_2.png',
       background: '/images/img__0x0.png',
-      onClick: () => console.log('Navigate to consultations')
+      onClick: () => console.log('Navigate to consultations'),
     },
     {
-      title: 'Patient\'s Previous Consultations',
+      title: "Patient's Previous Consultations",
       image: '/images/img_image_3.png',
       background: '/images/img__1.png',
-      onClick: () => console.log('Navigate to patient history')
+      onClick: () => console.log('Navigate to patient history'),
     },
     {
       title: 'Important links lab test results',
       image: '/images/img_image_4.png',
       background: '/images/img__2.png',
-      onClick: () => console.log('Navigate to lab results')
-    }
+      onClick: () => console.log('Navigate to lab results'),
+    },
   ];
 
   return (
-    <div className="relative w-[1440px] h-[841px] bg-global-3">
-      {/* Sidebar */}
-      <Sidebar />
-      
-      {/* Header */}
-      <Header />
-      
-      {/* Main Content Area */}
-      <div className="absolute top-[100px] left-[336px] flex gap-0">
-        {/* Text Editor Section */}
-        <div className="w-[676px] h-[688px] bg-global-4 rounded-[10px] border border-global-1 border-opacity-30">
-          {/* Formatting Controls */}
-          <div className="flex items-center gap-4 mt-[17px] ml-[22px]">
-            <Dropdown
-              options={fontOptions}
-              value="Inter (Medium)"
-              onChange={handleFontChange}
-              className="w-[137px]"
-            />
-            <Dropdown
-              options={sizeOptions}
-              value="Size: 12"
-              onChange={handleSizeChange}
-              className="w-[92px]"
-            />
-          </div>
-          
-          {/* Text Content Area */}
-          <div className="mt-[26px] mx-[22px]">
-            <textarea
-              value={textContent}
-              onChange={(e) => setTextContent(e.target.value)}
-              className="w-[619px] h-[472px] text-[17px] font-opensans font-light leading-[23px] text-global-1 bg-transparent border-none outline-none resize-none"
-              placeholder="Start typing your medical notes here..."
-            />
-          </div>
-          
-          {/* Voice Recording Controls */}
-          <div className="absolute bottom-[18px] left-[363px] w-[622px] h-[119px] bg-global-2 rounded-[10px] flex flex-col items-center justify-center">
-            {/* Recording Controls Row */}
-            <div className="flex items-center gap-[20px] mb-[10px]">
-              <button
-                onClick={handleStartRecording}
-                className={`w-[42px] h-[42px] rounded-full flex items-center justify-center transition-all ${
-                  voiceState.isRecording ? 'opacity-50' : 'hover:opacity-80'
-                }`}
-                disabled={voiceState.isRecording}
-              >
-                <img src="/images/img_proiconsrecord.svg" alt="Record" className="w-[42px] h-[42px]" />
-              </button>
-              
-              <button
-                onClick={handlePauseRecording}
-                className="w-[64px] h-[64px] rounded-full flex items-center justify-center hover:opacity-80 transition-all"
-              >
-                <img src="/images/img_group_13.svg" alt="Pause/Play" className="w-[64px] h-[64px]" />
-              </button>
-              
-              <button
-                onClick={handleStopRecording}
-                className="w-[42px] h-[42px] rounded-full flex items-center justify-center hover:opacity-80 transition-all"
-              >
-                <img src="/images/img_fluentrecordstop48regular.svg" alt="Stop" className="w-[42px] h-[42px]" />
-              </button>
-              
-              <Button
-                onClick={handleSubmit}
-                variant="primary"
-                className="ml-[41px] px-[25px] py-[10px]"
-              >
-                Submit
-              </Button>
-            </div>
-            
-            {/* Audio Timeline */}
-            <div className="flex items-center gap-[9px]">
-              <span className="text-[14px] font-opensans font-normal leading-[20px] text-global-2">
-                {voiceState.duration}
-              </span>
-              <img src="/images/img_group.svg" alt="Audio waveform" className="w-[108px] h-[27px]" />
-              <button
-                onClick={handleDeleteRecording}
-                className="w-[17px] h-[17px] hover:opacity-80 transition-all"
-              >
-                <img src="/images/img_icbaselinedelete.svg" alt="Delete" className="w-[17px] h-[17px]" />
-              </button>
-            </div>
-          </div>
+    <div className="flex gap-0">
+      {/* Text Editor Section */}
+      <div className="relative w-[676px] h-[688px] bg-global-4 rounded-[10px] border border-global-1 border-opacity-30">
+        {/* Formatting Controls */}
+        <div className="flex items-center gap-4 mt-[17px] ml-[22px]">
+          <Dropdown
+            options={fontOptions}
+            value="Inter (Medium)"
+            onChange={handleFontChange}
+            className="w-[137px]"
+          />
+          <Dropdown
+            options={sizeOptions}
+            value="Size: 12"
+            onChange={handleSizeChange}
+            className="w-[92px]"
+          />
         </div>
-        
-        {/* Vertical Divider */}
-        <div className="w-[1px] h-[688px] bg-global-1 opacity-30 mx-[12px]"></div>
-        
-        {/* Quick Access Panel */}
-        <div className="w-[351px] h-[688px] flex flex-col gap-[20px]">
-          {quickAccessItems.map((item, index) => (
-            <div
-              key={index}
-              onClick={item.onClick}
-              className="relative w-[351px] h-[157px] rounded-[11px] cursor-pointer hover:opacity-90 transition-all shadow-sm overflow-hidden"
-              style={{
-                backgroundImage: `url(${item.background})`,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center'
-              }}
+
+        {/* Text Content Area */}
+        <div className="mt-[26px] mx-[22px]">
+          <textarea
+            value={textContent}
+            onChange={(e) => setTextContent(e.target.value)}
+            className="w-[619px] h-[472px] text-[17px] font-opensans font-light leading-[23px] text-global-1 bg-transparent border-none outline-none resize-none"
+            placeholder="Start typing your medical notes here..."
+          />
+        </div>
+
+        {/* Voice Recording Controls */}
+        <div className="absolute bottom-[18px] left-1/2 transform -translate-x-1/2 w-[622px] h-[119px] bg-global-2 rounded-[10px] flex flex-col items-center justify-center">
+          {/* Recording Controls Row */}
+          <div className="flex items-center gap-[20px] mb-[10px]">
+            <button
+              onClick={handleStartRecording}
+              className={`w-[42px] h-[42px] rounded-full flex items-center justify-center transition-all ${
+                voiceState.isRecording ? 'opacity-50' : 'hover:opacity-80'
+              }`}
+              disabled={voiceState.isRecording}
             >
-              <div className="absolute inset-0 bg-black bg-opacity-40 rounded-[11px]"></div>
-              <div className="relative z-10 flex flex-col items-center justify-center h-full text-center px-4">
-                <img 
-                  src={item.image} 
-                  alt={item.title}
-                  className="w-[53px] h-[53px] mb-4"
-                />
-                <h3 className="text-[19px] font-raleway font-semibold leading-[23px] text-global-3 max-w-[261px]">
-                  {item.title}
-                </h3>
-              </div>
-            </div>
-          ))}
+              <img
+                src="/images/img_proiconsrecord.svg"
+                alt="Record"
+                className="w-[42px] h-[42px]"
+              />
+            </button>
+
+            <button
+              onClick={handlePauseRecording}
+              className="w-[64px] h-[64px] rounded-full flex items-center justify-center hover:opacity-80 transition-all"
+            >
+              <img src="/images/img_group_13.svg" alt="Pause/Play" className="w-[64px] h-[64px]" />
+            </button>
+
+            <button
+              onClick={handleStopRecording}
+              className="w-[42px] h-[42px] rounded-full flex items-center justify-center hover:opacity-80 transition-all"
+            >
+              <img
+                src="/images/img_fluentrecordstop48regular.svg"
+                alt="Stop"
+                className="w-[42px] h-[42px]"
+              />
+            </button>
+
+            <Button
+              onClick={handleSubmit}
+              variant="primary"
+              className="ml-[41px] px-[25px] py-[10px]"
+            >
+              Submit
+            </Button>
+          </div>
+
+          {/* Audio Timeline */}
+          <div className="flex items-center gap-[9px]">
+            <span className="text-[14px] font-opensans font-normal leading-[20px] text-global-2">
+              {voiceState.duration}
+            </span>
+            <img src="/images/img_group.svg" alt="Audio waveform" className="w-[108px] h-[27px]" />
+            <button
+              onClick={handleDeleteRecording}
+              className="w-[17px] h-[17px] hover:opacity-80 transition-all"
+            >
+              <img
+                src="/images/img_icbaselinedelete.svg"
+                alt="Delete"
+                className="w-[17px] h-[17px]"
+              />
+            </button>
+          </div>
         </div>
+      </div>
+
+      {/* Vertical Divider */}
+      <div className="w-[1px] h-[688px] bg-global-1 opacity-30 mx-[12px]"></div>
+
+      {/* Quick Access Panel */}
+      <div className="w-[351px] h-[688px] flex flex-col gap-[20px]">
+        {quickAccessItems.map((item, index) => (
+          <div
+            key={index}
+            onClick={item.onClick}
+            className="relative w-[351px] h-[157px] rounded-[11px] cursor-pointer hover:opacity-90 transition-all shadow-sm overflow-hidden"
+            style={{
+              backgroundImage: `url(${item.background})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+            }}
+          >
+            <div className="absolute inset-0 bg-black bg-opacity-40 rounded-[11px]"></div>
+            <div className="relative z-10 flex flex-col items-center justify-center h-full text-center px-4">
+              <img src={item.image} alt={item.title} className="w-[53px] h-[53px] mb-4" />
+              <h3 className="text-[19px] font-raleway font-semibold leading-[23px] text-global-3 max-w-[261px]">
+                {item.title}
+              </h3>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/Extra/index.tsx
+++ b/src/pages/Extra/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ExtraPage: React.FC = () => {
+  return <div className="p-4">Extra feature placeholder</div>;
+};
+
+export default ExtraPage;

--- a/src/pages/ExtraThree/index.tsx
+++ b/src/pages/ExtraThree/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ExtraThreePage: React.FC = () => {
+  return <div className="p-4">Third extra feature</div>;
+};
+
+export default ExtraThreePage;

--- a/src/pages/ExtraTwo/index.tsx
+++ b/src/pages/ExtraTwo/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ExtraTwoPage: React.FC = () => {
+  return <div className="p-4">Second extra feature</div>;
+};
+
+export default ExtraTwoPage;

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ProfilePage: React.FC = () => {
+  return <div className="p-4">Profile page placeholder</div>;
+};
+
+export default ProfilePage;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -22,6 +22,14 @@
     /* Button Colors */
     --button-bg-1: #1472ff;
   }
+
+  .dark {
+    --global-bg-3: #1e1e1e;
+    --global-bg-4: #2c2c2c;
+    --global-text-1: #ffffff;
+    --global-text-2: #ffffffb3;
+    --global-text-3: #ffffff;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- add ThemeContext and ThemeProvider for light and dark themes
- implement responsive sidebar, header, and layout with theme toggle
- expand routing with calendar, profile, and extra pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688deda0a1d48333b0b1ba0635161ecc